### PR TITLE
Updated console app

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,7 @@
 mode: ContinuousDelivery
 tag-prefix: '[vV]'  
 assembly-versioning-scheme: MajorMinorPatch
-branches:
-  master:
-    tag: beta
+branches: {}
 ignore:
   sha: []
 merge-message-formats: {}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,9 @@
 mode: ContinuousDelivery
-tag-prefix: '[vV]'
-branches: {}
+tag-prefix: '[vV]'  
+assembly-versioning-scheme: MajorMinorPatch
+branches:
+  master:
+    tag: beta
 ignore:
   sha: []
 merge-message-formats: {}

--- a/src/dotnet-structuring.console/Program.cs
+++ b/src/dotnet-structuring.console/Program.cs
@@ -36,47 +36,47 @@ namespace dotnet_structuring.console
                 Argument = new Argument<string>(getDefaultValue: () => @"C:\Develop")
             };
 
-            var artifactsOption = new Option("-a", "Create artifacts Directory")
+            var artifactsOption = new Option("--artifacts", "Create artifacts Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
-            artifactsOption.AddAlias("--artifacts");
+            artifactsOption.AddAlias("-a");
 
-            var buildOption = new Option("-b", "Create build Directory")
+            var buildOption = new Option("--build", "Create build Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
-            buildOption.AddAlias("--build");
+            buildOption.AddAlias("-b");
 
-            var docsOption = new Option("-d", "Create docs Directory")
+            var docsOption = new Option("--docs", "Create docs Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => true),
             };
-            docsOption.AddAlias("--docs");
+            docsOption.AddAlias("-d");
 
-            var libOption = new Option("-l", "Create lib Directory")
+            var libOption = new Option("--lib", "Create lib Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
-            libOption.AddAlias("--lib");
+            libOption.AddAlias("-l");
 
-            var samplesOption = new Option("-s", "Create samples Directory")
+            var samplesOption = new Option("--samples", "Create samples Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
-            samplesOption.AddAlias("--samples");
+            samplesOption.AddAlias("-s");
 
-            var packagesOption = new Option("-p", "Create packages Directory")
+            var packagesOption = new Option("--packages", "Create packages Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
-            packagesOption.AddAlias("--packages");
+            packagesOption.AddAlias("-p");
 
-            var testOption = new Option("-t", "Create test Directory")
+            var testOption = new Option("--test", "Create test Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
-            testOption.AddAlias("--test");
+            testOption.AddAlias("-t");
             var newCommand = new Command("new")
                 {
                 teamplateOption,
@@ -98,37 +98,37 @@ namespace dotnet_structuring.console
             rootCommand.InvokeAsync(args).Wait();
         }
 
-        public delegate void SetupDelegate(string template, string name, string output, bool a, bool b, bool d, bool l, bool s, bool p, bool t);
+        public delegate void SetupDelegate(string template, string name, string output, bool artifacts, bool build, bool docs, bool lib, bool samples, bool packages, bool test);
 
-        public static void Run(string template, string name, string output, bool a, bool b, bool d, bool l, bool s, bool p, bool t)
+        public static void Run(string template, string name, string output, bool artifacts, bool build, bool docs, bool lib, bool samples, bool packages, bool test)
         {
             string NETCommand;
 
-            if (a)
+            if (artifacts)
             {
                 Directories.Add("artifacts");
             }
-            if (b)
+            if (build)
             {
                 Directories.Add("build");
             }
-            if (d)
+            if (docs)
             {
                 Directories.Add("docs");
             }
-            if (l)
+            if (lib)
             {
                 Directories.Add("lib");
             }
-            if (s)
+            if (samples)
             {
                 Directories.Add("samples");
             }
-            if (p)
+            if (packages)
             {
                 Directories.Add("packages");
             }
-            if (t)
+            if (test)
             {
                 Directories.Add("test");
             }

--- a/src/dotnet-structuring.console/Program.cs
+++ b/src/dotnet-structuring.console/Program.cs
@@ -21,110 +21,119 @@ namespace dotnet_structuring.console
         {
             // Create a root command with some options
             var rootCommand = new RootCommand();
-
+            var teamplateOption = new Option(
+                             "--template",
+                             "Choose a Template of the 'dotnet new' command")
+            {
+                Argument = new Argument<string>(getDefaultValue: () => "console")
+            };
+            var nameOption = new Option(
+                        "--name",
+                        "Name of the Project being created")
+            {
+                Argument = new Argument<string>(getDefaultValue: () => "NewApp")
+            };
+            var outputOption = new Option(
+                        "--output",
+                        "Output Directory")
+            {
+                Argument = new Argument<string>(getDefaultValue: () => @"C:\Develop")
+            };
+            var artifactsOption = new Option(
+                        "-a",
+                        "Create artifacts Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => false)
+            };
+            var buildOption = new Option(
+                        "-b",
+                        "Create build Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => false)
+            };
+            var docsOption = new Option(
+                        "-d",
+                        "Create docs Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => true),
+            };
+            var libOption = new Option(
+                        "-l",
+                        "Create lib Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => false)
+                
+            };
+            var samplesOption = new Option(
+                        "-s",
+                        "Create samples Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => false)
+            };
+            var packagesOption = new Option(
+                        "-p",
+                        "Create packages Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => false)
+            };
+            var testOption = new Option(
+                        "-t",
+                        "Create test Directory")
+            {
+                Argument = new Argument<bool>(getDefaultValue: () => false)
+            };
             var newCommand = new Command("new")
                 {
-                    new Option(
-                        "-template",
-                        "Choose a Template of the 'dotnet new' command")
-                    {
-                        Argument = new Argument<string>(getDefaultValue: () => "console")
-                    },
-                    new Option(
-                        "-name",
-                        "Name of the Project being created")
-                    {
-                        Argument = new Argument<string>(getDefaultValue: () => "NewApp")
-                    },
-                    new Option(
-                        "-output",
-                        "Output Directory")
-                    {
-                        Argument = new Argument<string>(getDefaultValue: () => @"C:\Develop")
-                    },
-                    new Option(
-                        "--artifacts",
-                        "Create artifacts Directory")
-                    {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
-                    new Option(
-                        "--build",
-                        "Create build Directory")
-                    {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
-                    new Option(
-                        "--docs",
-                        "Create docs Directory")
-                    {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
-                    new Option(
-                        "--lib",
-                        "Create lib Directory")
-                    {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
-                    new Option(
-                        "--samples",
-                        "Create samples Directory")
-                    {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
-                    new Option(
-                        "--packages",
-                        "Create packages Directory")
-                        {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
-                       new Option(
-                        "--test",
-                        "Create test Directory")
-                    {
-                        Argument = new Argument<bool>(getDefaultValue: () => false)
-                    },
+                teamplateOption,
+                nameOption,
+                outputOption,
+                artifactsOption,
+                buildOption,
+                docsOption,
+                libOption,
+                samplesOption,
+                packagesOption,
+                testOption
                 };
             rootCommand.Add(newCommand);
             rootCommand.Description = "dotnet-structuring";
-
             newCommand.Handler = CommandHandler.Create(@delegate);
 
             // Parse the incoming args and invoke the handler
             rootCommand.InvokeAsync(args).Wait();
         }
 
-        public delegate void SetupDelegate(string template, string name, string output, bool artifacts, bool build, bool docs, bool lib, bool samples, bool packages, bool test);
+        public delegate void SetupDelegate(string template, string name, string output, bool a, bool b, bool d, bool l, bool s, bool p, bool t);
 
-        public static void Run(string template, string name, string output, bool artifacts, bool build, bool docs, bool lib, bool samples, bool packages, bool test)
+        public static void Run(string template, string name, string output, bool a, bool b, bool d, bool l, bool s, bool p, bool t)
         {
             string NETCommand;
 
-            if (artifacts)
+            if (a)
             {
                 Directories.Add("artifacts");
             }
-            if (build)
+            if (b)
             {
                 Directories.Add("build");
             }
-            if (docs)
+            if (d)
             {
                 Directories.Add("docs");
             }
-            if (lib)
+            if (l)
             {
                 Directories.Add("lib");
             }
-            if (samples)
+            if (s)
             {
                 Directories.Add("samples");
             }
-            if (packages)
+            if (p)
             {
                 Directories.Add("packages");
             }
-            if (test)
+            if (t)
             {
                 Directories.Add("test");
             }

--- a/src/dotnet-structuring.console/Program.cs
+++ b/src/dotnet-structuring.console/Program.cs
@@ -21,69 +21,58 @@ namespace dotnet_structuring.console
         {
             // Create a root command with some options
             var rootCommand = new RootCommand();
-            var teamplateOption = new Option(
-                             "--template",
-                             "Choose a Template of the 'dotnet new' command")
+            var teamplateOption = new Option("--template", "Choose a Template of the 'dotnet new' command")
             {
                 Argument = new Argument<string>(getDefaultValue: () => "console")
             };
-            var nameOption = new Option(
-                        "--name",
-                        "Name of the Project being created")
+
+            var nameOption = new Option("--name", "Name of the Project being created")
             {
                 Argument = new Argument<string>(getDefaultValue: () => "NewApp")
             };
-            var outputOption = new Option(
-                        "--output",
-                        "Output Directory")
+
+            var outputOption = new Option("--output", "Output Directory")
             {
                 Argument = new Argument<string>(getDefaultValue: () => @"C:\Develop")
             };
-            var artifactsOption = new Option(
-                        "-a",
-                        "Create artifacts Directory")
+
+            var artifactsOption = new Option("-a", "Create artifacts Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
             artifactsOption.AddAlias("--artifacts");
-            var buildOption = new Option(
-                        "-b",
-                        "Create build Directory")
+
+            var buildOption = new Option("-b", "Create build Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
             buildOption.AddAlias("--build");
-            var docsOption = new Option(
-                        "-d",
-                        "Create docs Directory")
+
+            var docsOption = new Option("-d", "Create docs Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => true),
             };
             docsOption.AddAlias("--docs");
-            var libOption = new Option(
-                        "-l",
-                        "Create lib Directory")
+
+            var libOption = new Option("-l", "Create lib Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
             libOption.AddAlias("--lib");
-            var samplesOption = new Option(
-                        "-s",
-                        "Create samples Directory")
+
+            var samplesOption = new Option("-s", "Create samples Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
             samplesOption.AddAlias("--samples");
-            var packagesOption = new Option(
-                        "-p",
-                        "Create packages Directory")
+
+            var packagesOption = new Option("-p", "Create packages Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
             packagesOption.AddAlias("--packages");
-            var testOption = new Option(
-                        "-t",
-                        "Create test Directory")
+
+            var testOption = new Option("-t", "Create test Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };

--- a/src/dotnet-structuring.console/Program.cs
+++ b/src/dotnet-structuring.console/Program.cs
@@ -45,43 +45,49 @@ namespace dotnet_structuring.console
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
+            artifactsOption.AddAlias("--artifacts");
             var buildOption = new Option(
                         "-b",
                         "Create build Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
+            buildOption.AddAlias("--build");
             var docsOption = new Option(
                         "-d",
                         "Create docs Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => true),
             };
+            docsOption.AddAlias("--docs");
             var libOption = new Option(
                         "-l",
                         "Create lib Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
-                
             };
+            libOption.AddAlias("--lib");
             var samplesOption = new Option(
                         "-s",
                         "Create samples Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
+            samplesOption.AddAlias("--samples");
             var packagesOption = new Option(
                         "-p",
                         "Create packages Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
+            packagesOption.AddAlias("--packages");
             var testOption = new Option(
                         "-t",
                         "Create test Directory")
             {
                 Argument = new Argument<bool>(getDefaultValue: () => false)
             };
+            testOption.AddAlias("--test");
             var newCommand = new Command("new")
                 {
                 teamplateOption,

--- a/src/dotnet-structuring.console/Program.cs
+++ b/src/dotnet-structuring.console/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.IO;
 using static dotnet_structuring.library.Helpers.Logging;
 
 namespace dotnet_structuring.console
@@ -33,7 +34,7 @@ namespace dotnet_structuring.console
 
             var outputOption = new Option("--output", "Output Directory")
             {
-                Argument = new Argument<string>(getDefaultValue: () => @"C:\Develop")
+                Argument = new Argument<string>(getDefaultValue: () => Directory.GetCurrentDirectory())
             };
 
             var artifactsOption = new Option("--artifacts", "Create artifacts Directory")

--- a/src/dotnet-structuring.console/Properties/launchSettings.json
+++ b/src/dotnet-structuring.console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-structuring.console": {
       "commandName": "Project",
-      "commandLineArgs": "new --build"
+      "commandLineArgs": "new -dla --packages"
     }
   }
 }

--- a/src/dotnet-structuring.console/Properties/launchSettings.json
+++ b/src/dotnet-structuring.console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-structuring.console": {
       "commandName": "Project",
-      "commandLineArgs": "new -dla --packages"
+      "commandLineArgs": "new -dla"
     }
   }
 }


### PR DESCRIPTION
# You can now use multi-flag options

## Examples:

1. `dotnet-structuring.console new -btp --template console --name TestApp`
That will create an _console application_ named _TestApp_ with the following extra directories: 
`build`, `test` and `packages`

2. `dotnet-structuring.console new --artifacts -lt --template console --name TestApp`
That will create an _console application_ named _TestApp_ with the following extra directories: 
`artifacts`, `lib` and `test`